### PR TITLE
Remove specialized methods from core

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,6 @@ to see here, apart from sketches and wild ideas for the moment.
 * reduce
 * filter
 * find
-* where
-* findWhere
 * reject
 * any (some)
 * all (every)
@@ -96,6 +94,8 @@ to see here, apart from sketches and wild ideas for the moment.
 * toPlainObject
 * size
 * partition
+* where
+* findWhere
 
 **Arrays**
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ to see here, apart from sketches and wild ideas for the moment.
 * all (every)
 * contains (includes)
 * invoke
-* pluck
 
 **Grouping**
 
@@ -96,6 +95,7 @@ to see here, apart from sketches and wild ideas for the moment.
 * partition
 * where
 * findWhere
+* pluck
 
 **Arrays**
 


### PR DESCRIPTION
They are now supported by their ~~better~~generic counterparts:

``` js
// Old
_.where(collection, {attr: 'value'});
// New
_.filter(collection, {attr: 'value'});

// Old
_.findWhere(collection, {attr: 'value'});
// New
_.find(collection, {attr: 'value'});

// Old
_.pluck(collection, 'attr');
// New
_.map(collection, 'attr');
```
